### PR TITLE
アイコン画像アップロードの機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,4 +74,5 @@ end
 gem 'carrierwave'
 gem 'devise'
 gem 'devise-i18n'
+gem 'image_processing'
 gem 'kaminari'

--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ group :test do
   gem 'selenium-webdriver'
 end
 
+gem 'activestorage-validator'
 gem 'carrierwave'
 gem 'devise'
 gem 'devise-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,6 +59,8 @@ GEM
       activerecord (= 8.0.2)
       activesupport (= 8.0.2)
       marcel (~> 1.0)
+    activestorage-validator (0.5.0)
+      rails (>= 6.1.0)
     activesupport (8.0.2)
       base64
       benchmark (>= 0.3)
@@ -423,6 +425,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activestorage-validator
   bootsnap
   brakeman
   capybara

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -433,6 +433,7 @@ DEPENDENCIES
   erb_lint
   faker
   i18n_generators
+  image_processing
   importmap-rails
   jbuilder
   kamal

--- a/app/assets/stylesheets/devise.css
+++ b/app/assets/stylesheets/devise.css
@@ -42,3 +42,7 @@ Devise
   margin: 12px 0 0;
   padding-inline-start: 1em;
 }
+
+.field_avatar {
+  display: block;
+}

--- a/app/assets/stylesheets/users.css
+++ b/app/assets/stylesheets/users.css
@@ -1,0 +1,7 @@
+/****************
+Users-avatar
+****************/
+
+.avatar img {
+  border-radius: 50%;
+}

--- a/app/assets/stylesheets/users.css
+++ b/app/assets/stylesheets/users.css
@@ -2,6 +2,10 @@
 Users-avatar
 ****************/
 
+.avatar {
+  height: 110px;
+}
+
 .avatar img {
   border-radius: 50%;
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,7 +10,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    keys = %i[name postal_code address self_introduction]
+    keys = %i[name postal_code address self_introduction avatar]
     devise_parameter_sanitizer.permit(:sign_up, keys:)
     devise_parameter_sanitizer.permit(:account_update, keys:)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@
 
 class UsersController < ApplicationController
   def index
-    @users = User.order(:id).page(params[:page])
+    @users = User.with_attached_avatar.order(:id).page(params[:page])
   end
 
   def show

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_one_attached :avatar
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,5 +3,8 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
   has_one_attached :avatar
+
+  validates :avatar, blob: { content_type: ['image/jpeg', 'image/png', 'image/gif'] }
 end

--- a/app/views/devise/registrations/_profile_fields.html.erb
+++ b/app/views/devise/registrations/_profile_fields.html.erb
@@ -17,3 +17,9 @@
   <%= f.label :self_introduction %><br />
   <%= f.text_area :self_introduction %>
 </div>
+
+<div class="field_avatar">
+  <%= f.label :avatar %><br />
+  <%= f.file_field :avatar %><br />
+  <%= t("devise.registrations.common.avatar_hint") %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -28,9 +28,10 @@
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
-  <div class="field">
-    <%= f.label :avatar, style: "display: block" %>
-    <%= f.file_field :avatar %>
+  <div class="field_avatar">
+    <%= f.label :avatar %><br />
+    <%= f.file_field :avatar %><br />
+    <%= t(".avatar_hint") %>
   </div>
 
   <div class="field">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -28,12 +28,6 @@
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
-  <div class="field_avatar">
-    <%= f.label :avatar %><br />
-    <%= f.file_field :avatar %><br />
-    <%= t(".avatar_hint") %>
-  </div>
-
   <div class="field">
     <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
     <%= f.password_field :current_password, autocomplete: "current-password" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -29,6 +29,11 @@
   </div>
 
   <div class="field">
+    <%= f.label :avatar, style: "display: block" %>
+    <%= f.file_field :avatar %>
+  </div>
+
+  <div class="field">
     <%= f.label :current_password %> <i>(<%= t('.we_need_your_current_password_to_confirm_your_changes') %>)</i><br />
     <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -1,5 +1,9 @@
 <div id="<%= dom_id user %>">
 
+  <p class="avatar">
+    <%= image_tag user.avatar.variant(resize_to_fill: [100, 100]) if user.avatar.attached? %>
+  </p>
+
   <p>
     <strong><%= User.human_attribute_name(:email) %>:</strong>
     <%= user.email %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -217,3 +217,4 @@ ja:
     registrations:
       edit:
         title: "アカウント編集"
+        avatar_hint: "jpg, png, gif 形式のみ対応しています。画像は正方形に切り抜かれます。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -215,6 +215,8 @@ ja:
   # devise-i18n-viewsをオーバーライド
   devise:
     registrations:
+      common:
+        avatar_hint: "jpg, png, gif 形式のみ対応しています。画像は正方形に切り抜かれます。"
       edit:
         title: "アカウント編集"
-        avatar_hint: "jpg, png, gif 形式のみ対応しています。画像は正方形に切り抜かれます。"
+

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -219,4 +219,3 @@ ja:
         avatar_hint: "jpg, png, gif 形式のみ対応しています。画像は正方形に切り抜かれます。"
       edit:
         title: "アカウント編集"
-

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -15,3 +15,4 @@ ja:
         postal_code: 郵便番号
         address: 住所
         self_introduction: 自己紹介文
+        avatar: アイコン画像

--- a/db/migrate/20251004012851_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20251004012851_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[7.0]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [ primary_key_type, foreign_key_type ]
+    end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,35 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_11_025033) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_04_012851) do
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
   create_table "books", force: :cascade do |t|
     t.string "title"
     t.text "memo"
@@ -35,4 +63,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_11_025033) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
 end


### PR DESCRIPTION
## 変更内容
アイコン画像アップロードの機能を追加しました。
### 詳細
#### Active Storageで画像アップロード機能を実装
- `image_processing`Gemを追加
- Active Storageが利用する3つのテーブルを追加
- 保存先にローカルを指定
- strong parametersに`avatar`を追加
- `User`モデルに`has_one_attached`を定義（1ユーザーにつき1枚の画像）
- 画像が大きい場合リサイズ
```
variant(resize_to_fill: [100, 100]) 
```
- `.with_attached_avatar`でN+1問題を防止
#### 'activestorage-validator'Gemを追加
- アップロード可能なファイルをjpg, png, gifの3種類に限定
#### i18nで日本語化
#### アイコン画像のビューを調整
   - アイコンの表示はリサイズ以外は要件に書かれていませんでしたが、以下の通り整えました。
      - 丸いアイコンでの表示
      - 画像がない場合でも、アバター部分の高さを固定
<img width="1317" height="625" alt="image" src="https://github.com/user-attachments/assets/8ffe92b1-5ce2-42db-9f68-63dd28b46f7e" />

     