### PR TITLE
日報およびコメント機能を実装

### DIFF
--- a/app/assets/stylesheets/scaffolds.css
+++ b/app/assets/stylesheets/scaffolds.css
@@ -260,6 +260,10 @@ Show
   object-fit: contain;
 }
 
+.comment:not(:last-child) {
+  margin-bottom: 1.5em;
+}
+
 /****************
 New and Edit
 ****************/

--- a/app/controllers/books/comments_controller.rb
+++ b/app/controllers/books/comments_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Books::CommentsController < CommentsController
+  def set_commentable
+    @commentable = Book.find(params[:book_id])
+  end
+
+  def render_commentable_show
+    @book = @commentable
+    @comments = @commentable.comments.includes(:user)
+    render 'books/show', status: :unprocessable_entity
+  end
+end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -9,7 +9,9 @@ class BooksController < ApplicationController
   end
 
   # GET /books/1 or /books/1.json
-  def show; end
+  def show
+    @comments = @book.comments
+  end
 
   # GET /books/new
   def new

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -10,7 +10,7 @@ class BooksController < ApplicationController
 
   # GET /books/1 or /books/1.json
   def show
-    @comments = @book.comments
+    @comments = @book.comments.includes(:user)
   end
 
   # GET /books/new

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -11,6 +11,7 @@ class BooksController < ApplicationController
   # GET /books/1 or /books/1.json
   def show
     @comments = @book.comments.includes(:user)
+    @comment = @book.comments.build
   end
 
   # GET /books/new

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class CommentsController < ApplicationController
+  before_action :set_commentable, only: %i[create]
+
+  def create
+    @comment = @commentable.comments.new(comment_params)
+    @comment.user = current_user
+
+    if @comment.save
+      redirect_to polymorphic_path(@commentable), notice: t('controllers.common.notice_create', name: Comment.model_name.human)
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_commentable
+    @commentable =
+      if params[:book_id]
+        Book.find(params[:book_id])
+      elsif params[:report_id]
+        Report.find(params[:report_id])
+      end
+  end
+
+  def comment_params
+    params.require(:comment).permit(:content)
+  end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -11,14 +11,14 @@ class CommentsController < ApplicationController
     if @comment.save
       redirect_to polymorphic_path(@commentable), notice: t('controllers.common.notice_create', name: Comment.model_name.human)
     else
-      render :new, status: :unprocessable_entity
+      render_commentable_show
     end
   end
 
   def destroy
     if @comment.user == current_user
-    @comment.destroy
-    redirect_to polymorphic_path(@commentable), notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
+      @comment.destroy
+      redirect_to polymorphic_path(@commentable), notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
     else
       redirect_to polymorphic_path(@commentable), alert: t('views.common.no_authorization')
     end
@@ -26,20 +26,11 @@ class CommentsController < ApplicationController
 
   private
 
-  def set_commentable
-    @commentable =
-      if params[:book_id]
-        Book.find(params[:book_id])
-      elsif params[:report_id]
-        Report.find(params[:report_id])
-      end
-  end
-
   def set_comment
     @comment = @commentable.comments.find(params[:id])
   end
 
   def comment_params
-    params.require(:comment).permit(:content)
+    params.expect(comment: %i[content])
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 class CommentsController < ApplicationController
-  before_action :set_commentable, only: %i[create]
+  before_action :set_commentable, only: %i[create destroy]
+  before_action :set_comment, only: %i[destroy]
 
   def create
     @comment = @commentable.comments.new(comment_params)
@@ -14,6 +15,15 @@ class CommentsController < ApplicationController
     end
   end
 
+  def destroy
+    if @comment.user == current_user
+    @comment.destroy
+    redirect_to polymorphic_path(@commentable), notice: t('controllers.common.notice_destroy', name: Comment.model_name.human)
+    else
+      redirect_to polymorphic_path(@commentable), alert: t('views.common.no_authorization')
+    end
+  end
+
   private
 
   def set_commentable
@@ -23,6 +33,10 @@ class CommentsController < ApplicationController
       elsif params[:report_id]
         Report.find(params[:report_id])
       end
+  end
+
+  def set_comment
+    @comment = @commentable.comments.find(params[:id])
   end
 
   def comment_params

--- a/app/controllers/reports/comments_controller.rb
+++ b/app/controllers/reports/comments_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class Reports::CommentsController < CommentsController
+  def set_commentable
+    @commentable = Report.find(params[:report_id])
+  end
+
+  def render_commentable_show
+    @report = @commentable
+    @comments = @commentable.comments.includes(:user)
+    render 'reports/show', status: :unprocessable_entity
+  end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -10,7 +10,9 @@ class ReportsController < ApplicationController
   end
 
   # GET /reports/1 or /reports/1.json
-  def show; end
+  def show
+    @comments = @report.comments
+  end
 
   # GET /reports/new
   def new

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -6,12 +6,12 @@ class ReportsController < ApplicationController
 
   # GET /reports or /reports.json
   def index
-    @reports = Report.order(:id).page(params[:page])
+    @reports = Report.includes(:user).order(:id).page(params[:page])
   end
 
   # GET /reports/1 or /reports/1.json
   def show
-    @comments = @report.comments
+    @comments = @report.comments.includes(:user)
   end
 
   # GET /reports/new

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,0 +1,70 @@
+class ReportsController < ApplicationController
+  before_action :set_report, only: %i[ show edit update destroy ]
+
+  # GET /reports or /reports.json
+  def index
+    @reports = Report.all
+  end
+
+  # GET /reports/1 or /reports/1.json
+  def show
+  end
+
+  # GET /reports/new
+  def new
+    @report = Report.new
+  end
+
+  # GET /reports/1/edit
+  def edit
+  end
+
+  # POST /reports or /reports.json
+  def create
+    @report = Report.new(report_params)
+
+    respond_to do |format|
+      if @report.save
+        format.html { redirect_to @report, notice: "Report was successfully created." }
+        format.json { render :show, status: :created, location: @report }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @report.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /reports/1 or /reports/1.json
+  def update
+    respond_to do |format|
+      if @report.update(report_params)
+        format.html { redirect_to @report, notice: "Report was successfully updated." }
+        format.json { render :show, status: :ok, location: @report }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @report.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /reports/1 or /reports/1.json
+  def destroy
+    @report.destroy!
+
+    respond_to do |format|
+      format.html { redirect_to reports_path, status: :see_other, notice: "Report was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_report
+      @report = Report.find(params.expect(:id))
+    end
+
+    # Only allow a list of trusted parameters through.
+    def report_params
+      params.expect(report: [ :title, :content, :user_id ])
+    end
+end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -4,12 +4,12 @@ class ReportsController < ApplicationController
   before_action :set_report, only: %i[show edit update destroy]
   before_action :ensure_user, only: %i[edit update destroy]
 
-  # GET /reports or /reports.json
+  # GET /reports
   def index
     @reports = Report.includes(:user).order(:id).page(params[:page])
   end
 
-  # GET /reports/1 or /reports/1.json
+  # GET /reports/1
   def show
     @comments = @report.comments.includes(:user)
     @comment = @report.comments.build
@@ -23,7 +23,7 @@ class ReportsController < ApplicationController
   # GET /reports/1/edit
   def edit; end
 
-  # POST /reports or /reports.json
+  # POST /reports
   def create
     @report = current_user.reports.build(report_params)
 
@@ -34,7 +34,7 @@ class ReportsController < ApplicationController
     end
   end
 
-  # PATCH/PUT /reports/1 or /reports/1.json
+  # PATCH/PUT /reports/1
   def update
     if @report.update(report_params)
       redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
@@ -43,7 +43,7 @@ class ReportsController < ApplicationController
     end
   end
 
-  # DELETE /reports/1 or /reports/1.json
+  # DELETE /reports/1
   def destroy
     @report.destroy!
 

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,14 +1,15 @@
+# frozen_string_literal: true
+
 class ReportsController < ApplicationController
-  before_action :set_report, only: %i[ show edit update destroy ]
+  before_action :set_report, only: %i[show edit update destroy]
 
   # GET /reports or /reports.json
   def index
-    @reports = Report.all
+    @reports = Report.order(:id).page(params[:page])
   end
 
   # GET /reports/1 or /reports/1.json
-  def show
-  end
+  def show; end
 
   # GET /reports/new
   def new
@@ -16,34 +17,25 @@ class ReportsController < ApplicationController
   end
 
   # GET /reports/1/edit
-  def edit
-  end
+  def edit; end
 
   # POST /reports or /reports.json
   def create
-    @report = Report.new(report_params)
+    @report = current_user.reports.build(report_params)
 
-    respond_to do |format|
-      if @report.save
-        format.html { redirect_to @report, notice: "Report was successfully created." }
-        format.json { render :show, status: :created, location: @report }
-      else
-        format.html { render :new, status: :unprocessable_entity }
-        format.json { render json: @report.errors, status: :unprocessable_entity }
-      end
+    if @report.save
+      redirect_to @report, notice: t('controllers.common.notice_create', name: Report.model_name.human)
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 
   # PATCH/PUT /reports/1 or /reports/1.json
   def update
-    respond_to do |format|
-      if @report.update(report_params)
-        format.html { redirect_to @report, notice: "Report was successfully updated." }
-        format.json { render :show, status: :ok, location: @report }
-      else
-        format.html { render :edit, status: :unprocessable_entity }
-        format.json { render json: @report.errors, status: :unprocessable_entity }
-      end
+    if @report.update(report_params)
+      redirect_to @report, notice: t('controllers.common.notice_update', name: Report.model_name.human)
+    else
+      render :edit, status: :unprocessable_entity
     end
   end
 
@@ -51,20 +43,18 @@ class ReportsController < ApplicationController
   def destroy
     @report.destroy!
 
-    respond_to do |format|
-      format.html { redirect_to reports_path, status: :see_other, notice: "Report was successfully destroyed." }
-      format.json { head :no_content }
-    end
+    redirect_to reports_path, status: :see_other, notice: t('controllers.common.notice_destroy', name: Report.model_name.human)
   end
 
   private
-    # Use callbacks to share common setup or constraints between actions.
-    def set_report
-      @report = Report.find(params.expect(:id))
-    end
 
-    # Only allow a list of trusted parameters through.
-    def report_params
-      params.expect(report: [ :title, :content, :user_id ])
-    end
+  # Use callbacks to share common setup or constraints between actions.
+  def set_report
+    @report = Report.find(params.expect(:id))
+  end
+
+  # Only allow a list of trusted parameters through.
+  def report_params
+    params.expect(report: %i[title content])
+  end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -2,6 +2,7 @@
 
 class ReportsController < ApplicationController
   before_action :set_report, only: %i[show edit update destroy]
+  before_action :ensure_user, only: %i[edit update destroy]
 
   # GET /reports or /reports.json
   def index
@@ -56,5 +57,9 @@ class ReportsController < ApplicationController
   # Only allow a list of trusted parameters through.
   def report_params
     params.expect(report: %i[title content])
+  end
+
+  def ensure_user
+    redirect_to new_report_path unless @report.user == current_user
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -63,6 +63,8 @@ class ReportsController < ApplicationController
   end
 
   def ensure_user
-    redirect_to report_path unless @report.user == current_user
+    return if @report.user == current_user
+
+    redirect_to @report, alert: t('views.common.no_authorization')
   end
 end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -12,6 +12,7 @@ class ReportsController < ApplicationController
   # GET /reports/1 or /reports/1.json
   def show
     @comments = @report.comments.includes(:user)
+    @comment = @report.comments.build
   end
 
   # GET /reports/new
@@ -62,6 +63,6 @@ class ReportsController < ApplicationController
   end
 
   def ensure_user
-    redirect_to new_report_path unless @report.user == current_user
+    redirect_to report_path unless @report.user == current_user
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,4 +2,5 @@
 
 class Book < ApplicationRecord
   mount_uploader :picture, PictureUploader
+  has_many :comments, as: :commentable, dependent: :destroy
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Comment < ApplicationRecord
+  belongs_to :commentable, polymorphic: true
+  belongs_to :user
+  validates :content, presence: true
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,0 +1,3 @@
+class Report < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,5 +2,6 @@
 
 class Report < ApplicationRecord
   belongs_to :user
+  has_many :comments, as: :commentable, dependent: :destroy
   validates :title, :content, presence: true
 end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Report < ApplicationRecord
   belongs_to :user
   validates :title, :content, presence: true

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,3 +1,4 @@
 class Report < ApplicationRecord
   belongs_to :user
+  validates :title, :content, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,5 @@ class User < ApplicationRecord
     attachable.variant :thumb, resize_to_limit: [150, 150]
   end
   has_many :reports, dependent: :destroy
+  has_many :comments, dependent: :destroy
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
   has_one_attached :avatar do |attachable|
     attachable.variant :thumb, resize_to_limit: [150, 150]
   end
+  has_many :reports, dependent: :destroy
 end

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -14,7 +14,7 @@
 <h2><p><%= t(Comment.model_name.human) %></h2>
 
 <% if @comments.any? %>
-  <%= render partial: "comments/comment" %>
+  <%= render partial: "comments/comment", locals: { commentable: @book } %>
 <% else %>
   <p><%= t('views.common.no_record', name: Comment.model_name.human) %></p>
 <% end %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -12,12 +12,7 @@
 </nav>
 
 <h2><p><%= t(Comment.model_name.human) %></h2>
-
-<% if @comments.any? %>
-  <%= render partial: "comments/comment", locals: { commentable: @book } %>
-<% else %>
-  <p><%= t('views.common.no_record', name: Comment.model_name.human) %></p>
-<% end %>
+<%= render partial: "comments/comments", locals: { commentable: @book, comments: @comments } %>
 
 <h2><%= t('views.common.new', name: Comment.model_name.human) %></h2>
 <%= render partial: "comments/form", locals: { commentable: @book } %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -10,3 +10,14 @@
 
   <%= button_to t('views.common.destroy', name: Book.model_name.human.downcase), @book, method: :delete %>
 </nav>
+
+<h2><p><%= t(Comment.model_name.human) %></h2>
+
+<% if @comments.any? %>
+  <%= render partial: "comments/comment" %>
+<% else %>
+  <p><%= t('views.common.no_record', name: Comment.model_name.human) %></p>
+<% end %>
+
+<h2><%= t('views.common.new', name: Comment.model_name.human) %></h2>
+<%= render partial: "comments/form", locals: { commentable: @book } %>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -1,7 +1,7 @@
 <h1><%= t('views.common.title_show', name: Book.model_name.human) %></h1>
 
 <div class="show-item">
-  <%= render @book %>
+  <%= render partial: "books/book", locals:{ book: @book } %>
 </div>
 
 <nav class="page-nav">
@@ -11,8 +11,13 @@
   <%= button_to t('views.common.destroy', name: Book.model_name.human.downcase), @book, method: :delete %>
 </nav>
 
-<h2><p><%= t(Comment.model_name.human) %></h2>
-<%= render partial: "comments/comments", locals: { commentable: @book, comments: @comments } %>
+<h2><%= Comment.model_name.human %></h2>
+
+<% if @comments.any? %>
+  <%= render partial: "comments/comment", collection: @comments, locals: { commentable: @book } %>
+<% else %>
+  <p><%= t('views.common.no_record', name: Comment.model_name.human) %></p>
+<% end %>
 
 <h2><%= t('views.common.new', name: Comment.model_name.human) %></h2>
 <%= render partial: "comments/form", locals: { commentable: @book } %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -6,11 +6,12 @@
   </p>
 
   <p>
-    <strong><%= Report.human_attribute_name(:created_at) %>:</strong>
+    <strong><%= Comment.human_attribute_name(:created_at) %>:</strong>
     <%= l(comment.created_at, format: :long) %>
   </p>
 
-  <p><strong><%= Comment.human_attribute_name(:content) %>:</strong>
+  <p>
+    <strong><%= Comment.human_attribute_name(:content) %>:</strong>
     <%= comment.content %>
   </p>
 

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,0 +1,17 @@
+<% @comments.each do |comment| %>
+  <div class="show-item">
+    <p>
+      <strong><%= User.model_name.human %>:</strong>
+      <%= comment.user.name || comment.user.email %>
+    </p>
+
+    <p>
+      <strong><%= Report.human_attribute_name(:created_at) %>:</strong>
+      <%= l(comment.created_at, format: :long) %>
+    </p>
+
+    <p><strong><%= Comment.human_attribute_name(:content) %>:</strong>
+      <%= comment.content %>
+    </p>
+  </div>
+<% end %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,5 +1,5 @@
 <% @comments.each do |comment| %>
-  <div class="show-item">
+  <div class="show-item comment">
     <p>
       <strong><%= User.model_name.human %>:</strong>
       <%= comment.user.name || comment.user.email %>
@@ -13,5 +13,10 @@
     <p><strong><%= Comment.human_attribute_name(:content) %>:</strong>
       <%= comment.content %>
     </p>
+
+    <% if comment.user == current_user %>
+      <%= button_to t('views.common.destroy', name: Comment.model_name.human), polymorphic_path([commentable, comment]), method: :delete %>
+    <% end %>
+
   </div>
 <% end %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,22 +1,21 @@
-<% @comments.each do |comment| %>
-  <div class="show-item comment">
-    <p>
-      <strong><%= User.model_name.human %>:</strong>
-      <%= comment.user.name || comment.user.email %>
-    </p>
+<div id="<%= dom_id comment %>" class="show-item comment">
 
-    <p>
-      <strong><%= Report.human_attribute_name(:created_at) %>:</strong>
-      <%= l(comment.created_at, format: :long) %>
-    </p>
+  <p>
+    <strong><%= User.model_name.human %>:</strong>
+    <%= comment.user.name.presence || comment.user.email %>
+  </p>
 
-    <p><strong><%= Comment.human_attribute_name(:content) %>:</strong>
-      <%= comment.content %>
-    </p>
+  <p>
+    <strong><%= Report.human_attribute_name(:created_at) %>:</strong>
+    <%= l(comment.created_at, format: :long) %>
+  </p>
 
-    <% if comment.user == current_user %>
-      <%= button_to t('views.common.destroy', name: Comment.model_name.human), polymorphic_path([commentable, comment]), method: :delete %>
-    <% end %>
+  <p><strong><%= Comment.human_attribute_name(:content) %>:</strong>
+    <%= comment.content %>
+  </p>
 
-  </div>
-<% end %>
+  <% if comment.user == current_user %>
+    <%= button_to t('views.common.destroy', name: Comment.model_name.human), polymorphic_path([commentable, comment]), method: :delete %>
+  <% end %>
+
+</div>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,5 +1,0 @@
-<% if comments.any? %>
-  <%= render partial: "comments/comment", collection: comments, locals: { commentable: commentable } %>
-<% else %>
-  <p><%= t('views.common.no_record', name: Comment.model_name.human) %></p>
-<% end %>

--- a/app/views/comments/_comments.html.erb
+++ b/app/views/comments/_comments.html.erb
@@ -1,0 +1,5 @@
+<% if comments.any? %>
+  <%= render partial: "comments/comment", collection: comments, locals: { commentable: commentable } %>
+<% else %>
+  <p><%= t('views.common.no_record', name: Comment.model_name.human) %></p>
+<% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,0 +1,9 @@
+<%= form_with(model: [commentable, commentable.comments.build]) do |form| %>
+
+  <div class="mb-3">
+    <%= form.label :content, class: "form-label", style: "display: block" %>
+    <%= form.text_area :content, required: true, class: "form-control" %>
+  </div>
+
+  <%= form.submit class: "btn btn-primary" %>
+<% end %>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,9 +1,20 @@
-<%= form_with(model: [commentable, commentable.comments.build]) do |form| %>
+<%= form_with(model: [commentable, @comment]) do |form| %>
+  <% if @comment.errors.any? %>
+    <div style="color: red">
+      <h2><%= t('views.common.validation_error', errors: i18n_error_count(@comment.errors.count), name: Comment.model_name.human) %>:</h2>
 
-  <div class="mb-3">
-    <%= form.label :content, class: "form-label", style: "display: block" %>
-    <%= form.text_area :content, required: true, class: "form-control" %>
+      <ul>
+        <% @comment.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :content, style: "display: block" %>
+    <%= form.text_area :content, required: true %>
   </div>
 
-  <%= form.submit class: "btn btn-primary" %>
+  <%= form.submit %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,6 +33,9 @@
           <li>
             <%= link_to User.model_name.human, users_path %>
           </li>
+          <li>
+            <%= link_to Report.model_name.human, reports_path %>
+          </li>
         </ul>
         <div class="title">
           <%# html_safeを使っているが、XSSは発生しないのを確認済み %>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with(model: report) do |form| %>
   <% if report.errors.any? %>
     <div style="color: red">
-      <h2><%= pluralize(report.errors.count, "error") %> prohibited this report from being saved:</h2>
+      <h2><%= t('views.common.validation_error', errors: i18n_error_count(report.errors.count), name: Report.model_name.human) %>:</h2>
 
       <ul>
         <% report.errors.each do |error| %>
@@ -13,17 +13,12 @@
 
   <div>
     <%= form.label :title, style: "display: block" %>
-    <%= form.text_field :title %>
+    <%= form.text_field :title, required: true %>
   </div>
 
   <div>
     <%= form.label :content, style: "display: block" %>
-    <%= form.textarea :content %>
-  </div>
-
-  <div>
-    <%= form.label :user_id, style: "display: block" %>
-    <%= form.text_field :user_id %>
+    <%= form.textarea :content, required: true %>
   </div>
 
   <div>

--- a/app/views/reports/_form.html.erb
+++ b/app/views/reports/_form.html.erb
@@ -1,0 +1,32 @@
+<%= form_with(model: report) do |form| %>
+  <% if report.errors.any? %>
+    <div style="color: red">
+      <h2><%= pluralize(report.errors.count, "error") %> prohibited this report from being saved:</h2>
+
+      <ul>
+        <% report.errors.each do |error| %>
+          <li><%= error.full_message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= form.label :title, style: "display: block" %>
+    <%= form.text_field :title %>
+  </div>
+
+  <div>
+    <%= form.label :content, style: "display: block" %>
+    <%= form.textarea :content %>
+  </div>
+
+  <div>
+    <%= form.label :user_id, style: "display: block" %>
+    <%= form.text_field :user_id %>
+  </div>
+
+  <div>
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -1,0 +1,17 @@
+<div id="<%= dom_id report %>">
+  <p>
+    <strong>Title:</strong>
+    <%= report.title %>
+  </p>
+
+  <p>
+    <strong>Content:</strong>
+    <%= report.content %>
+  </p>
+
+  <p>
+    <strong>User:</strong>
+    <%= report.user_id %>
+  </p>
+
+</div>

--- a/app/views/reports/_report.html.erb
+++ b/app/views/reports/_report.html.erb
@@ -1,17 +1,22 @@
 <div id="<%= dom_id report %>">
   <p>
-    <strong>Title:</strong>
+    <strong><%= User.model_name.human %>:</strong>
+    <%= report.user.name.presence || report.user.email %>
+  </p>
+
+  <p>
+    <strong><%= Report.human_attribute_name(:title) %>:</strong>
     <%= report.title %>
   </p>
 
   <p>
-    <strong>Content:</strong>
-    <%= report.content %>
+    <strong><%= Report.human_attribute_name(:created_at) %>:</strong>
+    <%= l(report.created_at, format: :long) %>
   </p>
 
   <p>
-    <strong>User:</strong>
-    <%= report.user_id %>
+    <strong><%= Report.human_attribute_name(:content) %>:</strong>
+    <%= report.content %>
   </p>
 
 </div>

--- a/app/views/reports/edit.html.erb
+++ b/app/views/reports/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Editing report" %>
+
+<h1>Editing report</h1>
+
+<%= render "form", report: @report %>
+
+<br>
+
+<div>
+  <%= link_to "Show this report", @report %> |
+  <%= link_to "Back to reports", reports_path %>
+</div>

--- a/app/views/reports/edit.html.erb
+++ b/app/views/reports/edit.html.erb
@@ -1,12 +1,13 @@
-<% content_for :title, "Editing report" %>
+<% title = t('views.common.title_edit', name: Report.model_name.human) %>
+<% content_for :title, title %>
 
-<h1>Editing report</h1>
+<h1><%= title %></h1>
 
 <%= render "form", report: @report %>
 
 <br>
 
-<div>
-  <%= link_to "Show this report", @report %> |
-  <%= link_to "Back to reports", reports_path %>
-</div>
+<nav class="page-nav">
+  <%= link_to t('views.common.show', name: Report.model_name.human), @report %> |
+  <%= link_to t('views.common.back', name: Report.model_name.human), reports_path %>
+</nav>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,0 +1,16 @@
+<p style="color: green"><%= notice %></p>
+
+<% content_for :title, "Reports" %>
+
+<h1>Reports</h1>
+
+<div id="reports">
+  <% @reports.each do |report| %>
+    <%= render report %>
+    <p>
+      <%= link_to "Show this report", report %>
+    </p>
+  <% end %>
+</div>
+
+<%= link_to "New report", new_report_path %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -1,16 +1,21 @@
-<p style="color: green"><%= notice %></p>
+<% title = t('views.common.title_index', name: Report.model_name.human) %>
+<% content_for :title, title %>
 
-<% content_for :title, "Reports" %>
+<h1><%= title %></h1>
 
-<h1>Reports</h1>
-
-<div id="reports">
+<div id="reports" class="index-items">
   <% @reports.each do |report| %>
-    <%= render report %>
-    <p>
-      <%= link_to "Show this report", report %>
-    </p>
+    <div class="index-item">
+      <%= render report %>
+      <p>
+        <%= link_to t('views.common.show', name: Report.model_name.human), report %>
+      </p>
+    </div>
   <% end %>
 </div>
 
-<%= link_to "New report", new_report_path %>
+<%= paginate @reports %>
+
+<nav class="page-nav">
+  <%= link_to t('views.common.new', name: Report.model_name.human), new_report_path %>
+</nav>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, "New report" %>
+
+<h1>New report</h1>
+
+<%= render "form", report: @report %>
+
+<br>
+
+<div>
+  <%= link_to "Back to reports", reports_path %>
+</div>

--- a/app/views/reports/new.html.erb
+++ b/app/views/reports/new.html.erb
@@ -1,11 +1,11 @@
-<% content_for :title, "New report" %>
+<% title = t('views.common.title_new', name: Report.model_name.human) %>
+<% content_for :title, title %>
 
-<h1>New report</h1>
-
+<h1><%= title %></h1>
 <%= render "form", report: @report %>
 
 <br>
 
-<div>
-  <%= link_to "Back to reports", reports_path %>
-</div>
+<nav class="page-nav">
+  <%= link_to t('views.common.back', name: Report.model_name.human), reports_path %>
+</nav>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,0 +1,10 @@
+<p style="color: green"><%= notice %></p>
+
+<%= render @report %>
+
+<div>
+  <%= link_to "Edit this report", edit_report_path(@report) %> |
+  <%= link_to "Back to reports", reports_path %>
+
+  <%= button_to "Destroy this report", @report, method: :delete %>
+</div>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -16,13 +16,7 @@
 </nav>
 
 <h2><p><%= t(Comment.model_name.human) %></h2>
-
-<% if @comments.any? %>
-  <%= render partial: "comments/comment", locals: { commentable: @report } %>
-<% else %>
-  <p><%= t('views.common.no_record', name: Comment.model_name.human) %></p>
-<% end %>
+<%= render partial: "comments/comments", locals: { commentable: @report, comments: @comments } %>
 
 <h2><%= t('views.common.new', name: Comment.model_name.human) %></h2>
 <%= render partial: "comments/form", locals: { commentable: @report } %>
-

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -14,3 +14,15 @@
     <%= link_to t('views.common.back', name: Report.model_name.human), reports_path %>
   <% end %>
 </nav>
+
+<h2><p><%= t(Comment.model_name.human) %></h2>
+
+<% if @comments.any? %>
+  <%= render partial: "comments/comment", locals: { commentable: @report } %>
+<% else %>
+  <p><%= t('views.common.no_record', name: Comment.model_name.human) %></p>
+<% end %>
+
+<h2><%= t('views.common.new', name: Comment.model_name.human) %></h2>
+<%= render partial: "comments/form", locals: { commentable: @report } %>
+

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,10 +1,12 @@
-<p style="color: green"><%= notice %></p>
+<h1><%= t('views.common.title_show', name: Report.model_name.human) %></h1>
 
-<%= render @report %>
-
-<div>
-  <%= link_to "Edit this report", edit_report_path(@report) %> |
-  <%= link_to "Back to reports", reports_path %>
-
-  <%= button_to "Destroy this report", @report, method: :delete %>
+<div class="show-item">
+  <%= render @report %>
 </div>
+
+<nav class="page-nav">
+  <%= link_to t('views.common.edit', name: Report.model_name.human), edit_report_path(@report) %> |
+  <%= link_to t('views.common.back', name: Report.model_name.human), reports_path %>
+
+  <%= button_to t('views.common.destroy', name: Report.model_name.human), @report, method: :delete %>
+</nav>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,7 +1,7 @@
 <h1><%= t('views.common.title_show', name: Report.model_name.human) %></h1>
 
 <div class="show-item">
-  <%= render @report %>
+  <%= render partial: "reports/report", locals:{ report: @report } %>
 </div>
 
 <nav class="page-nav">
@@ -15,8 +15,13 @@
   <% end %>
 </nav>
 
-<h2><p><%= t(Comment.model_name.human) %></h2>
-<%= render partial: "comments/comments", locals: { commentable: @report, comments: @comments } %>
+<h2><%= Comment.model_name.human %></h2>
+
+<% if @comments.any? %>
+  <%= render partial: "comments/comment", collection: @comments, locals: { commentable: @report } %>
+<% else %>
+  <p><%= t('views.common.no_record', name: Comment.model_name.human) %></p>
+<% end %>
 
 <h2><%= t('views.common.new', name: Comment.model_name.human) %></h2>
 <%= render partial: "comments/form", locals: { commentable: @report } %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -5,8 +5,12 @@
 </div>
 
 <nav class="page-nav">
-  <%= link_to t('views.common.edit', name: Report.model_name.human), edit_report_path(@report) %> |
-  <%= link_to t('views.common.back', name: Report.model_name.human), reports_path %>
+  <% if @report.user == current_user %>
+    <%= link_to t('views.common.edit', name: Report.model_name.human), edit_report_path(@report) %> |
+    <%= link_to t('views.common.back', name: Report.model_name.human), reports_path %>
 
-  <%= button_to t('views.common.destroy', name: Report.model_name.human), @report, method: :delete %>
+    <%= button_to t('views.common.destroy', name: Report.model_name.human), @report, method: :delete %>
+  <% else %>
+    <%= link_to t('views.common.back', name: Report.model_name.human), reports_path %>
+  <% end %>
 </nav>

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,7 @@ module BooksApp
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    # config.time_zone = "Central Time (US & Canada)"
+    config.time_zone = "Asia/Tokyo"
     # config.eager_load_paths << Rails.root.join("extras")
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -197,6 +197,7 @@ ja:
       validation_error: "%{errors}があるため、この%{name}は保存できませんでした"
       title_show: "%{name}の詳細"
       sign_out: ログアウト
+      no_record: "%{name}はまだありません。"
     pagination:
       first: '« 最初'
       last: '最後 »'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -198,6 +198,7 @@ ja:
       title_show: "%{name}の詳細"
       sign_out: ログアウト
       no_record: "%{name}はまだありません。"
+      no_authorization: "権限がありません。"
     pagination:
       first: '« 最初'
       last: '最後 »'

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -4,6 +4,7 @@ ja:
       book: 本
       user: ユーザ
       report: 日報
+      comment: コメント
 
     attributes:
       book:
@@ -19,5 +20,8 @@ ja:
         avatar: ユーザ画像
       report:
         title: タイトル
+        content: 本文
+        created_at: 投稿日時
+      comment:
         content: 本文
         created_at: 投稿日時

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -3,6 +3,7 @@ ja:
     models:
       book: 本
       user: ユーザ
+      report: 日報
 
     attributes:
       book:
@@ -16,3 +17,7 @@ ja:
         address: 住所
         self_introduction: 自己紹介文
         avatar: ユーザ画像
+      report:
+        title: タイトル
+        content: 本文
+        created_at: 投稿日時

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :reports
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users
   root to: 'books#index'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,13 @@
 Rails.application.routes.draw do
-  resources :reports
+  resources :reports do
+    resources :comments
+  end
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users
   root to: 'books#index'
-  resources :books
+  resources :books do
+    resources :comments
+  end
   resources :users, only: %i(index show)
 
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,12 @@
 Rails.application.routes.draw do
   resources :reports do
-    resources :comments
+    resources :comments, module: :reports
   end
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
   devise_for :users
   root to: 'books#index'
   resources :books do
-    resources :comments
+    resources :comments, module: :books
   end
   resources :users, only: %i(index show)
 

--- a/db/migrate/20251009060931_create_reports.rb
+++ b/db/migrate/20251009060931_create_reports.rb
@@ -1,0 +1,11 @@
+class CreateReports < ActiveRecord::Migration[8.0]
+  def change
+    create_table :reports do |t|
+      t.string :title, null: false
+      t.text :content, null: false
+      t.belongs_to :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251010020308_create_comments.rb
+++ b/db/migrate/20251010020308_create_comments.rb
@@ -7,7 +7,5 @@ class CreateComments < ActiveRecord::Migration[8.0]
 
       t.timestamps
     end
-
-    add_index :comments, [:commentable_type, :commentable_id]
   end
 end

--- a/db/migrate/20251010020308_create_comments.rb
+++ b/db/migrate/20251010020308_create_comments.rb
@@ -1,0 +1,11 @@
+class CreateComments < ActiveRecord::Migration[8.0]
+  def change
+    create_table :comments do |t|
+      t.text :content, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :commentable, polymorphic: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20251010020308_create_comments.rb
+++ b/db/migrate/20251010020308_create_comments.rb
@@ -7,5 +7,7 @@ class CreateComments < ActiveRecord::Migration[8.0]
 
       t.timestamps
     end
+
+    add_index :comments, [:commentable_type, :commentable_id]
   end
 end

--- a/db/migrate/20251016185811_add_index_to_comments_commentable.rb
+++ b/db/migrate/20251016185811_add_index_to_comments_commentable.rb
@@ -1,5 +1,0 @@
-class AddIndexToCommentsCommentable < ActiveRecord::Migration[8.0]
-  def change
-    add_index :comments, [:commentable_type, :commentable_id]
-  end
-end

--- a/db/migrate/20251016185811_add_index_to_comments_commentable.rb
+++ b/db/migrate/20251016185811_add_index_to_comments_commentable.rb
@@ -1,0 +1,5 @@
+class AddIndexToCommentsCommentable < ActiveRecord::Migration[8.0]
+  def change
+    add_index :comments, [:commentable_type, :commentable_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_09_060931) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_16_185811) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -48,6 +48,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_060931) do
     t.string "picture"
   end
 
+  create_table "comments", force: :cascade do |t|
+    t.text "content", null: false
+    t.integer "user_id", null: false
+    t.string "commentable_type"
+    t.integer "commentable_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
+    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
   create_table "reports", force: :cascade do |t|
     t.string "title", null: false
     t.text "content", null: false
@@ -75,5 +87,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_09_060931) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "comments", "users"
   add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_23_233449) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_09_060931) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -48,6 +48,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_23_233449) do
     t.string "picture"
   end
 
+  create_table "reports", force: :cascade do |t|
+    t.string "title", null: false
+    t.text "content", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_reports_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -66,4 +75,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_23_233449) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "reports", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -56,7 +56,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_10_020308) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
-    t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable_type_and_commentable_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_16_185811) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_10_020308) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false


### PR DESCRIPTION
## 内容
- 日報機能を追加しました。
-  本及び日報の詳細ページにコメントが投稿できるようにしました。

## 詳細
### ①レポート機能の追加(Report)
- repotsのCRUDを実装
   - タイトルと本文を必須項目とし、HTML5の必須チェック機能およびrailsでのバリデーション済。
   - `created_at`を日報の投稿日として設定。
- `current_user`を用い、編集・削除は本人のみ可能。
### ②タイムゾーンをTokyoに設定
### ③コメント機能の追加(Comments)
- 本と日報の詳細画面からコメントの閲覧・投稿・削除機能を実装。（編集機能はなし）
   - 本文を必須項目とし、HTML5の必須チェック機能およびrailsでのバリデーション済。
   - 投稿・削除機能は本人のみ可能。
   - 投稿者はユーザー名、設定がなければメールアドレスを表示
- 関連付けの設定
   - 本と日報を`commentable`としてポリモーフィック関連付けを実装。
   - ユーザーとも関連付けを設定。
   - 本、日報、ユーザーが削除された際にはコメントが消えるように`dependent: :destroy`を実装。
 - `Books::CommentsController`  ,  `Reports::CommentsController`を作成し、名前空間で整理。
### ④各ページで日本語対応